### PR TITLE
Minor: @handle property in character

### DIFF
--- a/src/renderer/src/components/CardForm.tsx
+++ b/src/renderer/src/components/CardForm.tsx
@@ -151,6 +151,19 @@ export default function CardForm({ cardBundle, onSuccessfulSubmit, formType }: C
               />
               <FormField
                 control={form.control}
+                name="character.handle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-tx-primary">Character @handle</FormLabel>
+                    <FormControl>
+                      <Input placeholder="@handle for your character (optional)" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
                 name="character.description"
                 render={({ field }) => (
                   <FormItem>

--- a/src/renderer/src/components/CardModal.tsx
+++ b/src/renderer/src/components/CardModal.tsx
@@ -52,7 +52,13 @@ function CardModal({ cardBundle, onCreateChat }: CardModalProps) {
         <div className="px-6 pb-6 pt-12">
           <div className="flex flex-row">
             <div className="w-[30rem] pr-10">
-              <div className="pb-2 text-2xl font-semibold text-tx-primary">{cardBundle.data.character.name}</div>
+              <div className="pb-2 text-2xl font-semibold text-tx-primary">
+                {cardBundle.data.character.name}
+                {cardBundle.data.character.handle &&
+                  <p className="text-tx-tertiary pb-1 text-sm font-medium">
+                    {`@${cardBundle.data.character.handle}`}
+                  </p> }
+              </div>
               <p className="text-tx-tertiary pb-1 text-sm font-medium">
                 {`created: ${time.isoToFriendly(cardBundle.data.meta.created_at)}`}
               </p>

--- a/src/renderer/src/components/ChatBar.tsx
+++ b/src/renderer/src/components/ChatBar.tsx
@@ -28,6 +28,12 @@ export default function ChatBar({
 }: ChatBarProps) {
   const [userInput, setUserInput] = useState<string>("");
 
+  const prompt = `Message ${
+    cardBundle.data.character.handle?.length
+      ? `@${cardBundle.data.character.handle}`
+      : cardBundle.data.character.name
+  }`
+
   // Dynamically expand the text area to fit the user's input
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   useEffect(() => {
@@ -91,7 +97,7 @@ export default function ChatBar({
             }
           }}
           value={userInput}
-          placeholder={`Message @Saku`}
+          placeholder={prompt}
           className="scroll-secondary text-tx-primary h-6 max-h-64 w-full resize-none overflow-y-auto bg-inherit px-2 leading-6
             placeholder:select-none focus:outline-none"
         />

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -7,7 +7,7 @@ export function cn(...inputs: ClassValue[]): string {
 }
 
 export function cardFormDataToCardData(data: CardFormData): CardData {
-  return {
+  const card: CardData = {
     spec: "anime.gf",
     spec_version: "1.0",
     character: {
@@ -32,4 +32,9 @@ export function cardFormDataToCardData(data: CardFormData): CardData {
       tags: data.meta.tags.split(",")
     }
   };
+
+  if (data.character.handle)
+    card.character.handle = data.character.handle;
+
+  return card as CardData;
 }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -12,6 +12,8 @@ export const config = {
     nameMinChars: 1,
     nameMaxChars: 128,
 
+    handleMaxChars: 15,
+
     descriptionMinChars: 0,
     descriptionMaxChars: 768,
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,7 @@ export interface CardData {
 
 export interface Character {
   name: string;
+  handle?: string;
   description: string;
   greeting: string;
   alt_greetings?: string[];
@@ -102,6 +103,12 @@ const characterFormSchema = z.object({
     .min(config.card.nameMinChars)
     .max(config.card.nameMaxChars)
     .regex(/^[a-zA-Z0-9 -]*$/, "Name can only contain letters, numbers, spaces, and hyphens"),
+  handle: z
+    .string()
+    .max(config.card.handleMaxChars)
+    .regex(/^[a-zA-Z0-9_-]*$/, "Handle can only contain letters, numbers, and dashes")
+    .optional(),
+
   description: z.string().min(config.card.descriptionMinChars).max(config.card.descriptionMaxChars),
   greeting: z.string().min(config.card.greetingMinChars).max(config.card.greetingMaxChars),
   msg_examples: z.string().min(config.card.msgExamplesMinChars).max(config.card.msgExamplesMaxChars),


### PR DESCRIPTION
## PR contents

Suggest changes to remove @Saku placeholder in chat input :
- Edit character type to add optional "handle" (string) property
- zod validator : <15 characters, optional
- Display below name in card modal
- Edit chat input placeholder "Message ... "
  - @handle if handle exists
  - character name otherwise
  
## Visuals


### Character card edit modal
<img width="1012" alt="image" src="https://github.com/cyanff/anime.gf/assets/26365493/f6ef0aff-cfe8-432f-b8d4-a210756b724b">
 

### Character card (with @handle)
<img width="1012" alt="image" src="https://github.com/cyanff/anime.gf/assets/26365493/3f601595-5e9d-47f6-a0d2-809fd6a74e04">

  
### Chat view (with @handle)
<img width="1012" alt="image" src="https://github.com/cyanff/anime.gf/assets/26365493/6ed0d2d2-5291-4bd7-a098-76dcb743e091">
  
### Chat view (using character name)
<img width="1012" alt="image" src="https://github.com/cyanff/anime.gf/assets/26365493/d35b8603-3534-4504-9e36-593b5b2cb09d">