### PR TITLE
ST cards: make avatar not a required data field

### DIFF
--- a/src/main/lib/cards.ts
+++ b/src/main/lib/cards.ts
@@ -20,7 +20,7 @@ const sillyCardSchema = z.object({
   spec_version: z.literal("2.0"),
   data: z.object({
     name: z.string(),
-    avatar: z.string(),
+    avatar: z.string().optional(),
     description: z.string(),
     personality: z.string(),
     scenario: z.string(),


### PR DESCRIPTION
The `avatar` field is not required and is only used internally as some sort of unique ID (cause it relates to a file name that is unique). It's not a part of shared card data, so don't validate it.