### PR TITLE
Persona/Adv.Settings: make the entire checkbox area clickable

### DIFF
--- a/src/renderer/src/app/settings/settings_advanced.tsx
+++ b/src/renderer/src/app/settings/settings_advanced.tsx
@@ -65,7 +65,7 @@ export default function SettingsAdvanced() {
                             setValue("closeToTray", checked === true);
                           }}
                         />
-                        <Label className="text-tx-primary">Close app to tray</Label>
+                        <Label className="text-tx-primary" htmlFor="closeToTray">Close app to tray</Label>
                       </div>
                     </FormControl>
                     <FormMessage />

--- a/src/renderer/src/components/PersonaFormModal.tsx
+++ b/src/renderer/src/components/PersonaFormModal.tsx
@@ -1,5 +1,6 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PencilSquareIcon } from "@heroicons/react/24/solid";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -138,7 +139,7 @@ export function PersonaFormModal({
           render={({ field }) => (
             <Checkbox
               className="rounded-[4px] border-[1px]"
-              id="message-streaming"
+              id="personaIsDefault"
               checked={field.value}
               onCheckedChange={(checked) => {
                 const val = checked === true ? true : false;
@@ -147,7 +148,7 @@ export function PersonaFormModal({
             />
           )}
         />
-        <span className="text-sm text-tx-primary">Make Default</span>
+        <Label className="text-sm text-tx-primary" htmlFor="personaIsDefault">Make Default</Label>
       </div>
 
       {/* Footer Controls*/}


### PR DESCRIPTION
It's hard to aim tiny checkboxes. Make the entire checkbox area clickable instead.