### PR TITLE
chat: preserve line breaks on message edit

### DIFF
--- a/src/renderer/src/components/Message.tsx
+++ b/src/renderer/src/components/Message.tsx
@@ -335,7 +335,7 @@ export default function Message({
                   // Show edit field if editing
                   <div
                     ref={editFieldRef}
-                    className="scroll-secondary h-auto w-full overflow-y-scroll text-wrap break-all bg-transparent text-left focus:outline-none"
+                    className="scroll-secondary h-auto w-full overflow-y-scroll text-wrap whitespace-pre-line break-all bg-transparent text-left focus:outline-none"
                     onKeyDown={(e) => {
                       if (e.key === "Enter" && !e.shiftKey) {
                         editSubmitHandler();


### PR DESCRIPTION
Self-explanatory. Line breaks are not respected when editing. 

Before:
<img width="1072" alt="image" src="https://github.com/cyanff/anime.gf/assets/18619528/39fb1f0c-94de-43b6-9933-e2d414a52e99">

After:
<img width="1072" alt="image" src="https://github.com/cyanff/anime.gf/assets/18619528/282093a3-06bc-457e-a4ce-0ea35cc915ea">
